### PR TITLE
added gridlines in between each coin data on the CoinTable

### DIFF
--- a/src/components/TableContent/TableContent.js
+++ b/src/components/TableContent/TableContent.js
@@ -8,6 +8,7 @@ import {
   LinkText,
   styledLink,
   PercentCell,
+  TableLine
 } from "./TableContent.styles";
 import {
   SmallGraph,
@@ -90,6 +91,7 @@ export default class TableContent extends React.Component {
                 />
               </div>
               <SmallGraph graphData={coin.sparkline_in_7d.price} />
+              <TableLine />
             </React.Fragment>
           );
         })}

--- a/src/components/TableContent/TableContent.styles.js
+++ b/src/components/TableContent/TableContent.styles.js
@@ -39,3 +39,8 @@ export const LinkText = styled.span`
     color: white;
   }
 `;
+
+export const TableLine = styled.span`
+  border-top: 1px solid #707070;
+  grid-column: 1 / 10;
+`;


### PR DESCRIPTION
I also did two pull requests that I merged myself because I was trying to figure out why a CSS style was causing an issue on Vercel, but not on my local. I was able to figure it out, so we're good.